### PR TITLE
Fix SexScore patch not changing results.

### DIFF
--- a/RJWSexperience/IdeologyAddon/Ideology/RJW_Patch_Ideo.cs
+++ b/RJWSexperience/IdeologyAddon/Ideology/RJW_Patch_Ideo.cs
@@ -307,10 +307,10 @@ namespace RJWSexperience.Ideology
             
 
             Ideo ideo = context.Inputs.Initiator.Ideo;
-            if (ideo != null) PreceptSextype(ideo, context.Inputs.Initiator.GetStatValue(xxx.sex_drive_stat), __result, 0, interaction);
+            if (ideo != null) PreceptSextype(ideo, context.Inputs.Initiator.GetStatValue(xxx.sex_drive_stat), ref __result, 0, interaction);
 
             ideo = context.Inputs.Partner.Ideo;
-            if (!context.Inputs.IsRape && ideo != null) PreceptSextype(ideo, context.Inputs.Partner.GetStatValue(xxx.sex_drive_stat), __result, 1, interaction);
+            if (!context.Inputs.IsRape && ideo != null) PreceptSextype(ideo, context.Inputs.Partner.GetStatValue(xxx.sex_drive_stat), ref __result, 1, interaction);
 
         }
 
@@ -321,7 +321,7 @@ namespace RJWSexperience.Ideology
             "Fisting",
         };
 
-        public static void PreceptSextype(Ideo ideo, float sexdrive, float result, int offset, InteractionWithExtension interaction)
+        public static void PreceptSextype(Ideo ideo, float sexdrive, ref float result, int offset, InteractionWithExtension interaction)
         {
             float mult = 8.0f * Math.Max(0.3f, 1 / Math.Max(0.01f, sexdrive));
             if ((interaction.Extension.rjwSextype == "Vaginal")


### PR DESCRIPTION
Just downloaded this mod the other day and noticed that the sex score patch wasn't behaving properly, people were disobeying their ideology.

Saw that a recent change was made to the sex score behaviour and found that the issue was that the resulting score was being passed by value and not by reference.

I did this change locally and everything worked fine, a rebuild will be needed for the binaries but I figured I should leave that to be done after a merge so the version number can be changed.

Apologies if this is the incorrect way to go about this, I'm more of a Java dev than a C# guy so there might be some best practices I'm missing.